### PR TITLE
Fix run_odrp in not-xterm mode so that IDL retains control.

### DIFF
--- a/scripts/run_odrp
+++ b/scripts/run_odrp
@@ -13,11 +13,16 @@
 
 #setenv OSIRIS_BACKBONE_DIR $KROOT/rel/default/idl/odrs/backbone
 
-if ($?1 & $1 == "-n") then
+if ( $?1 & $1 == "-n" ) then
+
     onintr -
     idl -IDL_STARTUP ${OSIRIS_BACKBONE_DIR}/drpStartup.pro ${OSIRIS_BACKBONE_DIR}/osiris_drp_backbone_startup.pro
     onintr
-else
+
+else 
+
     #start drp
     xterm +ls -sb -sl 5000 -T 'OSIRIS DRP' -e idl -IDL_STARTUP ${OSIRIS_BACKBONE_DIR}/drpStartup.pro ${OSIRIS_BACKBONE_DIR}/osiris_drp_backbone_startup.pro
+
 endif
+

--- a/scripts/run_odrp
+++ b/scripts/run_odrp
@@ -14,7 +14,9 @@
 #setenv OSIRIS_BACKBONE_DIR $KROOT/rel/default/idl/odrs/backbone
 
 if ($?1 & $1 == "-n") then
+    onintr -
     idl -IDL_STARTUP ${OSIRIS_BACKBONE_DIR}/drpStartup.pro ${OSIRIS_BACKBONE_DIR}/osiris_drp_backbone_startup.pro
+    onintr
 else
     #start drp
     xterm +ls -sb -sl 5000 -T 'OSIRIS DRP' -e idl -IDL_STARTUP ${OSIRIS_BACKBONE_DIR}/drpStartup.pro ${OSIRIS_BACKBONE_DIR}/osiris_drp_backbone_startup.pro


### PR DESCRIPTION
This makes it so that csh doesn't intercept the keyboard interrupt when calling IDL. Therefore, when you ^C during the ORDP loop, that ^C is not passed back to csh.

Before, the ^C would be handled by IDL, then elevated to the parent csh, causing csh to terminate the shell script, but leaving IDL running in an odd state in the background.

This should address #14 