### PR TITLE
Ability to silence setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ You can change all of the relevant OSIRIS variables later by running ``osirisSet
 
 ```
 $ osirisSetup -n /my/path/to/osiris/drp/
+Setting OSIRIS_ROOT=/my/path/to/osiris/drp/
+Successfully setup OSIRIS DRP environment.
+The DRP is in /my/path/to/osiris/drp/
+```
+
+You can add these lines to your ``.bashrc`` file or other startup profile if you want to set up the osiris environment variables for each of your shell sessions. Add lines like this to your profile:
+
+```
+OSIRIS_VERBOSE=0
+source scripts/osirisSetup.sh
+osirisSetup /my/path/to/osiris/drp/
 ```
 
 ### Environment Setup in CSH
@@ -68,6 +79,14 @@ Using OSIRIS_ROOT=/my/path/to/osiris/drp/
 Successfully setup OSIRIS DRP environment.
 The DRP is in /my/path/to/osiris/drp/
 You might want to add /my/path/to/osiris/drp/scripts to your PATH.
+```
+
+You can add these lines to your ``.cshrc`` file or other startup profile if you want to set up the osiris environment variables for each of your shell sessions. Add lines like this to your profile:
+
+```
+set OSIRIS_VERBOSE=0
+setenv OSIRIS_ROOT=/my/path/to/osiris/drp/
+source scripts/osirisSetup.csh
 ```
 
 ## Running the Pipeline

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and you should see that the pipeline has been built correctly. Be sure you are u
 
 ## OSIRIS Environment
 
-The OSIRIS DRP requires that you set various environment variables to that it knows how to find and run the pipeline. Instructions are below for bash (should work for other POSIX compliant shells) and CSH.
+The OSIRIS DRP requires that you set various environment variables to that it knows how to find and run the pipeline. Instructions are below for bash (should work for other POSIX compliant shells) and c-shell. If you want to set up your environment every time you start your shell (e.g. via ``.cshrc`` or ``.bashrc``), you should set ``OSIRIS_VERBOSE=0`` to silence the output of the setup scripts. Otherwise, they will print useful messages about the setup of your OSIRIS pipeline environment.
 
 ### Environment Setup in Bash
 

--- a/scripts/osirisSetup.csh
+++ b/scripts/osirisSetup.csh
@@ -1,22 +1,38 @@
-# Make the user set OSIRIS_ROOT
+# Script to set OSIRIS environment variables.
 set CONTINUE=1
 
+if (! $?OSIRIS_VERBOSE) then       
+  set OSIRIS_VERBOSE="1"
+else
+  if ("$OSIRIS_VERBOSE" == "")  then
+      set OSIRIS_VERBOSE="0"
+  endif
+endif
+
 if ! $?OSIRIS_ROOT then
-    echo "The OSIRIS DRP needs $OSIRIS_ROOT to be set."
-    echo "$ setenv OSIRIS_ROOT /path/to/my/drp"
+    if ("$OSIRIS_VERBOSE" != "0") then 
+        echo "The OSIRIS DRP needs $OSIRIS_ROOT to be set."
+        echo "$ setenv OSIRIS_ROOT /path/to/my/drp"
+    endif
     set CONTINUE=0
     
 endif
 
-echo "Using OSIRIS_ROOT=$OSIRIS_ROOT"
+if ("$OSIRIS_VERBOSE" != "0") then
+    echo "Using OSIRIS_ROOT=$OSIRIS_ROOT"
+endif
 if (! -d "$OSIRIS_ROOT/backbone") then
-    echo "Can't find the $OSIRIS_ROOT/backbone/ directory."
-    echo 'Be sure that $OSIRIS_ROOT is set correctly.'
+    if ("$OSIRIS_VERBOSE" != "0") then
+        echo "Can't find the $OSIRIS_ROOT/backbone/ directory."
+        echo 'Be sure that $OSIRIS_ROOT is set correctly.'
+    endif
     set CONTINUE=0
 else
   if (! -d "$OSIRIS_ROOT/modules") then
-      echo "Can't find the $OSIRIS_ROOT/modules/ directory."
-      echo 'Be sure that $OSIRIS_ROOT is set correctly.'
+      if ("$OSIRIS_VERBOSE" != "0") then
+          echo "Can't find the $OSIRIS_ROOT/modules/ directory."
+          echo 'Be sure that $OSIRIS_ROOT is set correctly.'
+      endif
       set CONTINUE=0
   endif
 endif
@@ -46,8 +62,10 @@ if ($CONTINUE == "1") then
     
     setenv OSIRIS_IDL_BASE $OSIRIS_ROOT
     
-    echo "Successfully setup OSIRIS DRP environment."
-    echo "The DRP is in $OSIRIS_ROOT"
-    echo "You might want to add $OSIRIS_ROOT/scripts to your PATH."
+    if ("$OSIRIS_VERBOSE" != "0") then
+        echo "Successfully setup OSIRIS DRP environment."
+        echo "The DRP is in $OSIRIS_ROOT"
+        echo "You might want to add $OSIRIS_ROOT/scripts to your PATH."
+    endif
 endif
 

--- a/scripts/osirisSetup.sh
+++ b/scripts/osirisSetup.sh
@@ -83,7 +83,9 @@ function osirisSetup() {
     
     if [[ $setpath -eq 1 ]]; then
         [[ $OSIRIS_VERBOSE -eq 1 ]] && echo "Adding ${OSIRIS_ROOT}/scripts to your path."
-        export PATH=${OSIRIS_ROOT}/scripts:${PATH}
+        if [ -d "${OSIRIS_ROOT}/scripts" ] && [[ ":$PATH:" != *":${OSIRIS_ROOT}/scripts:"* ]]; then
+            export PATH="${OSIRIS_ROOT}/scripts${PATH:+":$PATH"}"
+        fi
     fi
     # Fixes a bug with awt on OSX
     export JAVA_TOOL_OPTIONS='-Djava.awt.headless=false'

--- a/scripts/osirisSetup.sh
+++ b/scripts/osirisSetup.sh
@@ -1,5 +1,6 @@
 function osirisSetup() {
     local OPTIND o a
+    local setpath
     
     function osirisSetup_usage() {
         echo "Usage: $FUNCNAME [-n] /my/path/to/osiris/DRF/" >&2
@@ -8,12 +9,13 @@ function osirisSetup() {
         echo "" >&2
         echo "Flags:" >&2
         echo "   -n  Do not adjust the \$PATH variable." >&2
+        echo "   -v  Be verbose." >&2
         echo "   -h  Show this message and exit." >&2
         echo "" >&2
     }
-    
+    OSIRIS_VERBOSE=${OSIRIS_VERBOSE:-1}
     setpath=1
-    while getopts hn opt; do
+    while getopts hvn opt; do
       case $opt in
         h)
           osirisSetup_usage
@@ -22,13 +24,16 @@ function osirisSetup() {
         n)
           setpath=0
           ;;
+        v)
+          OSIRIS_VERBOSE=1
+          ;;
         \?)
           echo "Invalid option: -$OPTARG" >&2
           ;;
       esac
     done
     
-    if [[ $# == 0 ]]; then
+    if [[ $# -eq 0 ]] && [[ $OSIRIS_VERBOSE -eq 1 ]]; then
         echo "No path to the OSIRIS pipeline was given."
         echo "Assuming you want the pipeline to be in the current directory"
     fi
@@ -38,15 +43,15 @@ function osirisSetup() {
     # which should be the root directory for the
     # OSIRIS pipeline.
     OSIRIS_ROOT=${1:-$PWD}
-    echo "Setting OSIRIS_ROOT=$OSIRIS_ROOT"
+    [[ $OSIRIS_VERBOSE -eq 1 ]] && echo "Setting OSIRIS_ROOT=$OSIRIS_ROOT"
     if [[ ! -d "$OSIRIS_ROOT/backbone" ]]; then
         echo "Can't find the $OSIRIS_ROOT/backbone/ directory."
-        osirisSetup_usage
+        [[ $OSIRIS_VERBOSE -eq 1 ]] && osirisSetup_usage
         return 1
     fi
     if [[ ! -d "$OSIRIS_ROOT/modules" ]]; then
         echo "Can't find the $OSIRIS_ROOT/modules/ directory."
-        osirisSetup_usage
+        [[ $OSIRIS_VERBOSE -eq 1 ]] && osirisSetup_usage
         return 1
     fi
     export OSIRIS_ROOT=$OSIRIS_ROOT
@@ -77,13 +82,13 @@ function osirisSetup() {
     export OSIRIS_IDL_BASE=$OSIRIS_ROOT
     
     if [[ $setpath -eq 1 ]]; then
-        echo "Adding ${OSIRIS_ROOT}/scripts to your path."
+        [[ $OSIRIS_VERBOSE -eq 1 ]] && echo "Adding ${OSIRIS_ROOT}/scripts to your path."
         export PATH=${OSIRIS_ROOT}/scripts:${PATH}
     fi
     # Fixes a bug with awt on OSX
     export JAVA_TOOL_OPTIONS='-Djava.awt.headless=false'
     
-    echo "Successfully setup OSIRIS DRP environment."
-    echo "The DRP is in $OSIRIS_ROOT"
+    [[ $OSIRIS_VERBOSE -eq 1 ]] && echo "Successfully setup OSIRIS DRP environment."
+    [[ $OSIRIS_VERBOSE -eq 1 ]] && echo "The DRP is in $OSIRIS_ROOT"
 };
-echo "To use the OSIRIS DRP, run osirisSetup /path/to/my/drp"
+[[ ${OSIRIS_VERBOSE:-1} -eq 1 ]] && echo "To use the OSIRIS DRP, run osirisSetup /path/to/my/drp"


### PR DESCRIPTION
Just set ``OSIRIS_VERBOSE=0`` before running the setup scripts. This is useful when source-ing these scripts in your ``.profile`` and you don't want to see messages every time.

Also added a comment to the README about this.